### PR TITLE
Improve test execution times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Consolidated and simplified tests
+- Consolidated, simplified tests [#29][pr-29] & made them faster [#31][pr-31]
+
+[pr-29]: https://github.com/MusicalNinjaDad/pytest-ipynb2/pull/29
+[pr-31]: https://github.com/MusicalNinjaDad/pytest-ipynb2/pull/31
 
 ## [0.2.1] - 2025-02-19
 

--- a/pytest_ipynb2/_pytester_helpers.py
+++ b/pytest_ipynb2/_pytester_helpers.py
@@ -13,6 +13,7 @@ import pytest
 if TYPE_CHECKING:
     from contextlib import suppress
     from pathlib import Path
+    from typing import Any
 
     with suppress(ImportError):  
         from typing import Self  # not type-checking on python < 3.11 so don't care if this fails
@@ -192,6 +193,10 @@ class CollectedDir:
     pytester_instance: pytest.Pytester
     dir_node: pytest.Dir
     items: list[pytest.Item]
+    path: Path | None = None
+
+    def __post_init__(self, *_: Any) -> None:
+        self.path = self.pytester_instance.path
 
 @dataclass(kw_only=True)
 class ExampleDir:

--- a/pytest_ipynb2/_pytester_helpers.py
+++ b/pytest_ipynb2/_pytester_helpers.py
@@ -294,7 +294,8 @@ def pytest_runtest_setup(item: pytest.Function) -> None:
             item.add_marker(pytest.mark.skip(reason="No expected results"))
 
 
-def pytest_collection_modifyitems(items: list[pytest.Function]) -> None:
+def pytest_collection_modifyitems(items: list[pytest.Function]) -> None: # pragma: no cover
+    # Tests will be needed if this ever becomes public functionality
     """xfail on presence of a custom marker: `xfail_for(tests:list[str], reasons:list[str])`."""  # noqa: D403
     for item in items:
         test_name = item.originalname.removeprefix("test_")

--- a/pytest_ipynb2/_pytester_helpers.py
+++ b/pytest_ipynb2/_pytester_helpers.py
@@ -279,14 +279,16 @@ def add_ipytest_magic(source: str) -> str:
     return f"%%ipytest\n\n{source}"
 
 
-def pytest_configure(config: pytest.Config) -> None:
+def pytest_configure(config: pytest.Config) -> None: # pragma: no cover
+    # Tests will be needed if this ever becomes public functionality
     """Register autoskip & xfail_for marks."""
     config.addinivalue_line("markers", "autoskip: automatically skip test if expected results not provided")
     config.addinivalue_line("markers", "xfail_for: xfail specified tests dynamically")
 
 
 @pytest.hookimpl(tryfirst=True)
-def pytest_runtest_setup(item: pytest.Function) -> None:
+def pytest_runtest_setup(item: pytest.Function) -> None: # pragma: no cover
+    # Tests will be needed if this ever becomes public functionality
     if item.get_closest_marker("autoskip"):
         test_name = item.originalname.removeprefix("test_")
         expected = getattr(item.callspec.getparam("expected_results"), test_name)

--- a/pytest_ipynb2/_pytester_helpers.py
+++ b/pytest_ipynb2/_pytester_helpers.py
@@ -192,17 +192,19 @@ class ExampleDir:
     """
 
     pytester: pytest.Pytester
-    items: list[pytest.Item]
     path: Path | None = None
 
-    def __init__(self, pytester: pytest.Pytester, items: list[pytest.Item]) -> None:
+    def __init__(self, pytester: pytest.Pytester) -> None:
         self.pytester = pytester
         self.path = self.pytester.path
-        self.items = items
 
     @cached_property
     def dir_node(self) -> pytest.Dir:
         return self.pytester.getpathnode(self.path)
+
+    @cached_property
+    def items(self) -> list[pytest.Item]:
+        return self.pytester.genitems([self.dir_node])
 
 
 @dataclass(kw_only=True)
@@ -241,11 +243,8 @@ def example_dir(request: ExampleDirRequest, pytester: pytest.Pytester) -> Exampl
             nbnode.cells.append(cellnode)
         nbformat.write(nb=nbnode, fp=pytester.path / f"{notebook}.ipynb")
 
-    dir_node = pytester.getpathnode(pytester.path)
-
     return ExampleDir(
         pytester=pytester,
-        items=pytester.genitems([dir_node]),
     )
 
 

--- a/pytest_ipynb2/_pytester_helpers.py
+++ b/pytest_ipynb2/_pytester_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass, field
 from textwrap import indent
 from typing import TYPE_CHECKING, Protocol
@@ -15,6 +16,12 @@ if TYPE_CHECKING:
 
     with suppress(ImportError):  # not type-checking on python < 3.11
         from typing import Self
+
+if sys.version_info < (3,10): # dataclass does not offer kw_only on python < 3.10
+    _dataclass = dataclass
+    def dataclass(*args, **kwargs):  # noqa: ANN002, ANN003
+        kwargs.__delitem__("kw_only")
+        return _dataclass(*args, **kwargs)
 
 
 class CollectionTree:

--- a/pytest_ipynb2/_pytester_helpers.py
+++ b/pytest_ipynb2/_pytester_helpers.py
@@ -267,7 +267,5 @@ def pytest_runtest_setup(item: pytest.Function) -> None:
     if item.get_closest_marker("autoskip"):
         test_name = item.originalname.removeprefix("test_")
         expected = getattr(item.callspec.getparam("expected_results"), test_name)
-        if expected or expected is None:
-            pass
-        else:
+        if not expected and expected is not None:
             item.add_marker(pytest.mark.skip(reason="No expected results"))

--- a/pytest_ipynb2/_pytester_helpers.py
+++ b/pytest_ipynb2/_pytester_helpers.py
@@ -206,6 +206,10 @@ class ExampleDir:
     def items(self) -> list[pytest.Item]:
         return self.pytester.genitems([self.dir_node])
 
+    @cached_property
+    def runresult(self) -> pytest.RunResult:
+        return self.pytester.runpytest()
+
 
 @dataclass(kw_only=True)
 class ExampleDirSpec:

--- a/pytest_ipynb2/_pytester_helpers.py
+++ b/pytest_ipynb2/_pytester_helpers.py
@@ -14,8 +14,8 @@ if TYPE_CHECKING:
     from contextlib import suppress
     from pathlib import Path
 
-    with suppress(ImportError):  # not type-checking on python < 3.11
-        from typing import Self
+    with suppress(ImportError):  
+        from typing import Self  # not type-checking on python < 3.11 so don't care if this fails
 
 if sys.version_info < (3,10): # dataclass does not offer kw_only on python < 3.10
     _dataclass = dataclass

--- a/pytest_ipynb2/_pytester_helpers.py
+++ b/pytest_ipynb2/_pytester_helpers.py
@@ -15,11 +15,13 @@ import pytest
 if TYPE_CHECKING:
     from contextlib import suppress
     from pathlib import Path
+    from types import FunctionType
+    from typing import Any
 
     with suppress(ImportError):
         from typing import Self  # not type-checking on python < 3.11 so don't care if this fails
 
-if sys.version_info < (3, 10):  # dataclass does not offer kw_only on python < 3.10
+if sys.version_info < (3, 10):  # dataclass does not offer kw_only on python < 3.10 # pragma: no cover
     _dataclass = dataclass
 
     def dataclass(*args, **kwargs):  # noqa: ANN002, ANN003
@@ -227,9 +229,12 @@ class ExampleDirSpec:
         return hash((self.conftest, self.ini, files, notebooks))
 
 
-class ExampleDirRequest(Protocol):
-    """Typehint to param passed to example_dir."""
+class FunctionRequest(Protocol):
+    function: FunctionType
+    keywords: dict[str, Any]
 
+
+class ExampleDirRequest(FunctionRequest):
     param: ExampleDirSpec
 
 

--- a/pytest_ipynb2/_pytester_helpers.py
+++ b/pytest_ipynb2/_pytester_helpers.py
@@ -6,6 +6,7 @@ import sys
 from dataclasses import dataclass, field
 from functools import cached_property
 from textwrap import indent
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Protocol
 
 import nbformat
@@ -219,6 +220,11 @@ class ExampleDirSpec:
     ini: str = ""
     files: list[Path] = field(default_factory=list)
     notebooks: dict[str, list[str]] = field(default_factory=dict)
+    
+    def __hash__(self) -> int:
+        files = tuple(self.files)
+        notebooks = tuple((notebook, "\n".join(contents)) for notebook, contents in self.notebooks.items())
+        return hash((self.conftest, self.ini, files, notebooks))
 
 
 class ExampleDirRequest(Protocol):

--- a/pytest_ipynb2/_pytester_helpers.py
+++ b/pytest_ipynb2/_pytester_helpers.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 if sys.version_info < (3,10): # dataclass does not offer kw_only on python < 3.10
     _dataclass = dataclass
     def dataclass(*args, **kwargs):  # noqa: ANN002, ANN003
-        kwargs.__delitem__("kw_only")
+        _ = kwargs.pop("kw_only", None)
         return _dataclass(*args, **kwargs)
 
 

--- a/pytest_ipynb2/_pytester_helpers.py
+++ b/pytest_ipynb2/_pytester_helpers.py
@@ -191,18 +191,18 @@ class ExampleDir:
     - `items`: list[pytest.Item]
     """
 
-    pytester_instance: pytest.Pytester
+    pytester: pytest.Pytester
     items: list[pytest.Item]
     path: Path | None = None
 
-    def __init__(self, pytester_instance: pytest.Pytester, items: list[pytest.Item]) -> None:
-        self.pytester_instance = pytester_instance
-        self.path = self.pytester_instance.path
+    def __init__(self, pytester: pytest.Pytester, items: list[pytest.Item]) -> None:
+        self.pytester = pytester
+        self.path = self.pytester.path
         self.items = items
 
     @cached_property
     def dir_node(self) -> pytest.Dir:
-        return self.pytester_instance.getpathnode(self.path)
+        return self.pytester.getpathnode(self.path)
 
 
 @dataclass(kw_only=True)
@@ -244,7 +244,7 @@ def example_dir(request: ExampleDirRequest, pytester: pytest.Pytester) -> Exampl
     dir_node = pytester.getpathnode(pytester.path)
 
     return ExampleDir(
-        pytester_instance=pytester,
+        pytester=pytester,
         items=pytester.genitems([dir_node]),
     )
 

--- a/pytest_ipynb2/_pytester_helpers.py
+++ b/pytest_ipynb2/_pytester_helpers.py
@@ -186,14 +186,13 @@ class CollectedDir:
     dir_node: pytest.Dir
     items: list[pytest.Item]
 
-
-@dataclass
+@dataclass(kw_only=True)
 class ExampleDir:
     """The various elements to set up a pytester instance."""
 
-    files: list[Path] = field(default_factory=list)
     conftest: str = ""
     ini: str = ""
+    files: list[Path] = field(default_factory=list)
     notebooks: dict[str, list[str]] = field(default_factory=dict)
 
 

--- a/ruff-main.toml
+++ b/ruff-main.toml
@@ -3,3 +3,6 @@ extend = "pyproject.toml"
 lint.extend-select = [
     "TD",  # TODOs need a description, even outside of `main`
 ]
+lint.extend-ignore = [
+    "TD002", # Don't need TODO authors - github issue gives that info
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,1 @@
-import pytest
-
 pytest_plugins = ["pytester", "pytest_ipynb2._pytester_helpers"]
-
-
-def pytest_configure(config: pytest.Config) -> None:
-    """Register custom xfail mark."""
-    config.addinivalue_line("markers", "xfail_for: xfail specified tests dynamically")
-
-
-def pytest_collection_modifyitems(items: list[pytest.Function]) -> None:
-    """xfail on presence of a custom marker: `xfail_for(tests:list[str], reasons:list[str])`."""  # noqa: D403
-    for item in items:
-        test_name = item.originalname.removeprefix("test_")
-        if xfail_for := item.get_closest_marker("xfail_for"):
-            for xfail_test, reason in zip(xfail_for.kwargs.get("tests"), xfail_for.kwargs.get("reasons")):
-                if xfail_test == test_name:
-                    item.add_marker(pytest.mark.xfail(reason=reason, strict=True))

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -5,14 +5,14 @@ import pytest
 
 import pytest_ipynb2
 import pytest_ipynb2.plugin
-from pytest_ipynb2._pytester_helpers import CollectedDir, CollectionTree, ExampleDir
+from pytest_ipynb2._pytester_helpers import CollectionTree, ExampleDir, ExampleDirSpec
 
 if TYPE_CHECKING:
     from pytest_ipynb2.plugin import Cell
 
 
 @pytest.fixture
-def expected_tree(request: pytest.FixtureRequest, example_dir: CollectedDir) -> CollectionTree:
+def expected_tree(request: pytest.FixtureRequest, example_dir: ExampleDir) -> CollectionTree:
     trees = {
         "notebook": {
             ("<Session  exitstatus='<UNSET>' testsfailed=0 testscollected=0>", pytest.Session): {
@@ -70,7 +70,7 @@ def expected_tree(request: pytest.FixtureRequest, example_dir: CollectedDir) -> 
     ["example_dir", "expected_tree"],
     [
         pytest.param(
-            ExampleDir(
+            ExampleDirSpec(
                 files=[Path("tests/assets/notebook.ipynb").absolute()],
                 conftest="pytest_plugins = ['pytest_ipynb2.plugin']",
             ),
@@ -78,7 +78,7 @@ def expected_tree(request: pytest.FixtureRequest, example_dir: CollectedDir) -> 
             id="Simple Notebook",
         ),
         pytest.param(
-            ExampleDir(
+            ExampleDirSpec(
                 files=[Path("tests/assets/notebook_2tests.ipynb").absolute()],
                 conftest="pytest_plugins = ['pytest_ipynb2.plugin']",
             ),
@@ -86,7 +86,7 @@ def expected_tree(request: pytest.FixtureRequest, example_dir: CollectedDir) -> 
             id="Notebook 2 tests",
         ),
         pytest.param(
-            ExampleDir(
+            ExampleDirSpec(
                 files=[
                     Path("tests/assets/notebook_2tests.ipynb").absolute(),
                     Path("tests/assets/notebook.ipynb").absolute(),
@@ -99,7 +99,7 @@ def expected_tree(request: pytest.FixtureRequest, example_dir: CollectedDir) -> 
     ],
     indirect=True,
 )
-def test_cell_collected(example_dir: CollectedDir, expected_tree: CollectionTree):
+def test_cell_collected(example_dir: ExampleDir, expected_tree: CollectionTree):
     assert CollectionTree.from_items(example_dir.items) == expected_tree
 
 
@@ -107,7 +107,7 @@ def test_cell_collected(example_dir: CollectedDir, expected_tree: CollectionTree
     "example_dir",
     [
         pytest.param(
-            ExampleDir(
+            ExampleDirSpec(
                 files=[Path("tests/assets/notebook.ipynb").absolute()],
                 conftest="pytest_plugins = ['pytest_ipynb2.plugin']",
             ),
@@ -116,7 +116,7 @@ def test_cell_collected(example_dir: CollectedDir, expected_tree: CollectionTree
     ],
     indirect=True,
 )
-def test_notebook_collection(example_dir: CollectedDir):
+def test_notebook_collection(example_dir: ExampleDir):
     files = list(example_dir.dir_node.collect())
     assert files
     assert len(files) == 1
@@ -128,7 +128,7 @@ def test_notebook_collection(example_dir: CollectedDir):
     "example_dir",
     [
         pytest.param(
-            ExampleDir(
+            ExampleDirSpec(
                 files=[Path("tests/assets/notebook.ipynb").absolute()],
                 conftest="pytest_plugins = ['pytest_ipynb2.plugin']",
             ),
@@ -137,7 +137,7 @@ def test_notebook_collection(example_dir: CollectedDir):
     ],
     indirect=True,
 )
-def test_cell_collection(example_dir: CollectedDir):
+def test_cell_collection(example_dir: ExampleDir):
     files = list(example_dir.dir_node.collect())
     cells = list(files[0].collect())
     assert cells
@@ -150,7 +150,7 @@ def test_cell_collection(example_dir: CollectedDir):
     "example_dir",
     [
         pytest.param(
-            ExampleDir(
+            ExampleDirSpec(
                 files=[Path("tests/assets/notebook.ipynb").absolute()],
                 conftest="pytest_plugins = ['pytest_ipynb2.plugin']",
             ),
@@ -159,7 +159,7 @@ def test_cell_collection(example_dir: CollectedDir):
     ],
     indirect=True,
 )
-def test_functions(example_dir: CollectedDir):
+def test_functions(example_dir: ExampleDir):
     files = list(example_dir.dir_node.collect())
     cells = list(files[0].collect())
     functions = list(cells[0].collect())
@@ -174,7 +174,7 @@ def test_functions(example_dir: CollectedDir):
     "example_dir",
     [
         pytest.param(
-            ExampleDir(
+            ExampleDirSpec(
                 files=[Path("tests/assets/notebook.ipynb").absolute()],
                 conftest="pytest_plugins = ['pytest_ipynb2.plugin']",
             ),
@@ -183,7 +183,7 @@ def test_functions(example_dir: CollectedDir):
     ],
     indirect=True,
 )
-def test_cellmodule_contents(example_dir: CollectedDir):
+def test_cellmodule_contents(example_dir: ExampleDir):
     cell: Cell = example_dir.items[0].parent
     expected_attrs = ["x", "y", "adder", "test_adder", "test_globals"]
     public_attrs = [attr for attr in cell._obj.__dict__ if not attr.startswith("__")]  # noqa: SLF001

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -16,7 +16,7 @@ def expected_tree(request: pytest.FixtureRequest, example_dir: CollectedDir) -> 
     trees = {
         "notebook": {
             ("<Session  exitstatus='<UNSET>' testsfailed=0 testscollected=0>", pytest.Session): {
-                (f"<Dir {example_dir.pytester_instance.path.name}>", pytest.Dir): {
+                (f"<Dir {example_dir.path.name}>", pytest.Dir): {
                     ("<Notebook notebook.ipynb>", pytest_ipynb2.plugin.Notebook): {
                         ("<Cell 4>", pytest_ipynb2.plugin.Cell): {
                             ("<Function test_adder>", pytest.Function): None,
@@ -28,7 +28,7 @@ def expected_tree(request: pytest.FixtureRequest, example_dir: CollectedDir) -> 
         },
         "notebook_2tests": {
             ("<Session  exitstatus='<UNSET>' testsfailed=0 testscollected=0>", pytest.Session): {
-                (f"<Dir {example_dir.pytester_instance.path.name}>", pytest.Dir): {
+                (f"<Dir {example_dir.path.name}>", pytest.Dir): {
                     ("<Notebook notebook_2tests.ipynb>", pytest_ipynb2.plugin.Notebook): {
                         ("<Cell 4>", pytest_ipynb2.plugin.Cell): {
                             ("<Function test_adder>", pytest.Function): None,
@@ -43,7 +43,7 @@ def expected_tree(request: pytest.FixtureRequest, example_dir: CollectedDir) -> 
         },
         "both notebooks": {
             ("<Session  exitstatus='<UNSET>' testsfailed=0 testscollected=0>", pytest.Session): {
-                (f"<Dir {example_dir.pytester_instance.path.name}>", pytest.Dir): {
+                (f"<Dir {example_dir.path.name}>", pytest.Dir): {
                     ("<Notebook notebook.ipynb>", pytest_ipynb2.plugin.Notebook): {
                         ("<Cell 4>", pytest_ipynb2.plugin.Cell): {
                             ("<Function test_adder>", pytest.Function): None,

--- a/tests/test_collectiontree.py
+++ b/tests/test_collectiontree.py
@@ -18,7 +18,7 @@ def expected_tree(request: pytest.FixtureRequest, example_dir: CollectedDir) -> 
     trees = {
         "test_module": {
             ("<Session  exitstatus='<UNSET>' testsfailed=0 testscollected=0>", pytest.Session): {
-                (f"<Dir {example_dir.pytester_instance.path.name}>", pytest.Dir): {
+                (f"<Dir {example_dir.path.name}>", pytest.Dir): {
                     ("<Module test_module.py>", pytest.Module): {
                         ("<Function test_adder>", pytest.Function): None,
                         ("<Function test_globals>", pytest.Function): None,
@@ -28,7 +28,7 @@ def expected_tree(request: pytest.FixtureRequest, example_dir: CollectedDir) -> 
         },
         "two_modules": {
             ("<Session  exitstatus='<UNSET>' testsfailed=0 testscollected=0>", pytest.Session): {
-                (f"<Dir {example_dir.pytester_instance.path.name}>", pytest.Dir): {
+                (f"<Dir {example_dir.path.name}>", pytest.Dir): {
                     ("<Module test_module.py>", pytest.Module): {
                         ("<Function test_adder>", pytest.Function): None,
                         ("<Function test_globals>", pytest.Function): None,

--- a/tests/test_collectiontree.py
+++ b/tests/test_collectiontree.py
@@ -113,7 +113,10 @@ def test_from_dict_single_root():
         ),
         pytest.param(
             ExampleDir(
-                [Path("tests/assets/test_module.py").absolute(), Path("tests/assets/test_othermodule.py").absolute()],
+                files=[
+                    Path("tests/assets/test_module.py").absolute(),
+                    Path("tests/assets/test_othermodule.py").absolute(),
+                ],
             ),
             "two_modules",
             id="Two modules",

--- a/tests/test_collectiontree.py
+++ b/tests/test_collectiontree.py
@@ -7,14 +7,14 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from pytest_ipynb2._pytester_helpers import CollectionTree, ExampleDir
+from pytest_ipynb2._pytester_helpers import CollectionTree, ExampleDirSpec
 
 if TYPE_CHECKING:
-    from pytest_ipynb2._pytester_helpers import CollectedDir
+    from pytest_ipynb2._pytester_helpers import ExampleDir
 
 
 @pytest.fixture
-def expected_tree(request: pytest.FixtureRequest, example_dir: CollectedDir) -> CollectionTree:
+def expected_tree(request: pytest.FixtureRequest, example_dir: ExampleDir) -> CollectionTree:
     trees = {
         "test_module": {
             ("<Session  exitstatus='<UNSET>' testsfailed=0 testscollected=0>", pytest.Session): {
@@ -105,14 +105,14 @@ def test_from_dict_single_root():
     ["example_dir", "expected_tree"],
     [
         pytest.param(
-            ExampleDir(
+            ExampleDirSpec(
                 files=[Path("tests/assets/test_module.py").absolute()],
             ),
             "test_module",
             id="One module",
         ),
         pytest.param(
-            ExampleDir(
+            ExampleDirSpec(
                 files=[
                     Path("tests/assets/test_module.py").absolute(),
                     Path("tests/assets/test_othermodule.py").absolute(),
@@ -124,7 +124,7 @@ def test_from_dict_single_root():
     ],
     indirect=True,
 )
-def test_from_items(example_dir: CollectedDir, expected_tree: CollectionTree):
+def test_from_items(example_dir: ExampleDir, expected_tree: CollectionTree):
     tree = CollectionTree.from_items(example_dir.items)
     assert tree == expected_tree
 

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -260,6 +260,7 @@ parametrized = pytest.mark.parametrize(
 
 
 @parametrized
+@pytest.mark.autoskip
 def test_outcomes(example_dir: ExampleDir, expected_results: ExpectedResults):
     try:
         example_dir.runresult.assert_outcomes(**expected_results.outcomes)
@@ -279,7 +280,8 @@ def test_logreport(example_dir: ExampleDir, expected_results: ExpectedResults):
 
 
 @parametrized
-def test_summary(pytester_results: pytest.RunResult, expected_results: ExpectedResults):
+@pytest.mark.autoskip
+def test_summary(example_dir: ExampleDir, expected_results: ExpectedResults):
     summary_regexes = ["[=]* short test summary info [=]*"]
     if expected_results.summary is not None:
         summary_regexes += [
@@ -292,9 +294,11 @@ def test_summary(pytester_results: pytest.RunResult, expected_results: ExpectedR
             for result, location, exceptiontype, message in expected_results.summary
         ]  # message is currently not provided until we fix Assertion re-writing
         summary_regexes += ["[=]*"]
-        pytester_results.stdout.re_match_lines(summary_regexes, consecutive=True)
+        example_dir.runresult.stdout.re_match_lines(summary_regexes, consecutive=True)
     else:
         assert (
-            re.search(f"{LINESTART}{summary_regexes[0]}{LINEEND}", str(pytester_results.stdout), flags=re.MULTILINE)
+            re.search(
+                f"{LINESTART}{summary_regexes[0]}{LINEEND}", str(example_dir.runresult.stdout), flags=re.MULTILINE,
+            )
             is None
         )

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -268,14 +268,14 @@ def test_outcomes(example_dir: ExampleDir, expected_results: ExpectedResults):
 
 
 @parametrized
-def test_logreport(pytester_results: pytest.RunResult, expected_results: ExpectedResults):
+def test_logreport(example_dir: ExampleDir, expected_results: ExpectedResults):
     stdout_regexes = [
         f"{LINESTART}{re.escape(filename)}{WHITESPACE}"
         f"{re.escape(outcomes)}{WHITESPACE}"
         f"{re.escape('[')}{progress:3d}%{re.escape(']')}{WHITESPACE}{LINEEND}"
         for filename, outcomes, progress in expected_results.logreport
     ]
-    pytester_results.stdout.re_match_lines(stdout_regexes, consecutive=True)
+    example_dir.runresult.stdout.re_match_lines(stdout_regexes, consecutive=True)
 
 
 @parametrized

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -260,11 +260,11 @@ parametrized = pytest.mark.parametrize(
 
 
 @parametrized
-def test_outcomes(pytester_results: pytest.RunResult, expected_results: ExpectedResults):
+def test_outcomes(example_dir: ExampleDir, expected_results: ExpectedResults):
     try:
-        pytester_results.assert_outcomes(**expected_results.outcomes)
+        example_dir.runresult.assert_outcomes(**expected_results.outcomes)
     except AssertionError:
-        pytest.fail(f"{pytester_results.stdout}")
+        pytest.fail(f"{example_dir.runresult.stdout}")
 
 
 @parametrized

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from pytest_ipynb2._pytester_helpers import CollectedDir, ExampleDir, add_ipytest_magic
+from pytest_ipynb2._pytester_helpers import ExampleDir, ExampleDirSpec, add_ipytest_magic
 
 LINESTART = "^"
 LINEEND = "$"
@@ -16,7 +16,7 @@ WHITESPACE = r"\s*"
 # TODO(MusicalNinjaDad): #30 Cache runpytest() results or set scopes to speed up tests
 @pytest.fixture
 def pytester_results(
-    example_dir: CollectedDir,
+    example_dir: ExampleDir,
     expected_results: ExpectedResults,
     request: pytest.FixtureRequest,
 ) -> pytest.RunResult:
@@ -47,7 +47,7 @@ parametrized = pytest.mark.parametrize(
     ["example_dir", "expected_results"],
     [
         pytest.param(
-            ExampleDir(
+            ExampleDirSpec(
                 files=[Path("tests/assets/notebook.ipynb").absolute()],
                 conftest="pytest_plugins = ['pytest_ipynb2.plugin']",
             ),
@@ -57,7 +57,7 @@ parametrized = pytest.mark.parametrize(
             id="Copied notebook",
         ),
         pytest.param(
-            ExampleDir(
+            ExampleDirSpec(
                 files=[Path("tests/assets/notebook_2tests.ipynb").absolute()],
                 conftest="pytest_plugins = ['pytest_ipynb2.plugin']",
             ),
@@ -67,7 +67,7 @@ parametrized = pytest.mark.parametrize(
             id="Copied notebook with 2 test cells",
         ),
         pytest.param(
-            ExampleDir(
+            ExampleDirSpec(
                 files=[
                     Path("tests/assets/notebook_2tests.ipynb").absolute(),
                     Path("tests/assets/notebook.ipynb").absolute(),
@@ -80,7 +80,7 @@ parametrized = pytest.mark.parametrize(
             id="Two copied notebooks - unsorted",
         ),
         pytest.param(
-            ExampleDir(
+            ExampleDirSpec(
                 conftest="pytest_plugins = ['pytest_ipynb2.plugin']",
                 notebooks={"passing": [add_ipytest_magic(Path("tests/assets/test_passing.py").read_text())]},
             ),
@@ -92,7 +92,7 @@ parametrized = pytest.mark.parametrize(
             id="Single Cell",
         ),
         pytest.param(
-            ExampleDir(
+            ExampleDirSpec(
                 conftest="pytest_plugins = ['pytest_ipynb2.plugin']",
                 notebooks={"failing": [add_ipytest_magic(Path("tests/assets/test_failing.py").read_text())]},
             ),
@@ -104,7 +104,7 @@ parametrized = pytest.mark.parametrize(
             id="Failing Test",
         ),
         pytest.param(
-            ExampleDir(
+            ExampleDirSpec(
                 conftest="pytest_plugins = ['pytest_ipynb2.plugin']",
                 notebooks={"fixture": [add_ipytest_magic(Path("tests/assets/test_fixture.py").read_text())]},
             ),
@@ -114,7 +114,7 @@ parametrized = pytest.mark.parametrize(
             id="Test with fixture",
         ),
         pytest.param(
-            ExampleDir(
+            ExampleDirSpec(
                 conftest="pytest_plugins = ['pytest_ipynb2.plugin']",
                 notebooks={"marks": [add_ipytest_magic(Path("tests/assets/test_param.py").read_text())]},
                 ini="addopts = -rx",
@@ -127,7 +127,7 @@ parametrized = pytest.mark.parametrize(
             id="Test with parameters and marks",
         ),
         pytest.param(
-            ExampleDir(
+            ExampleDirSpec(
                 conftest="pytest_plugins = ['pytest_ipynb2.plugin']",
                 notebooks={
                     "autoconfig": [
@@ -143,7 +143,7 @@ parametrized = pytest.mark.parametrize(
             id="Notebook calls autoconfig",
         ),
         pytest.param(
-            ExampleDir(
+            ExampleDirSpec(
                 conftest="pytest_plugins = ['pytest_ipynb2.plugin']",
                 notebooks={
                     "notests": [Path("tests/assets/test_module.py").read_text()],
@@ -155,7 +155,7 @@ parametrized = pytest.mark.parametrize(
             id="No ipytest cells",
         ),
         pytest.param(
-            ExampleDir(
+            ExampleDirSpec(
                 conftest="pytest_plugins = ['pytest_ipynb2.plugin']",
                 notebooks={
                     "nocells": [],
@@ -167,7 +167,7 @@ parametrized = pytest.mark.parametrize(
             id="Empty notebook",
         ),
         pytest.param(
-            ExampleDir(
+            ExampleDirSpec(
                 conftest="pytest_plugins = ['pytest_ipynb2.plugin']",
                 notebooks={
                     "comments": [
@@ -182,7 +182,7 @@ parametrized = pytest.mark.parametrize(
             id="ipytest not first line",
         ),
         pytest.param(
-            ExampleDir(
+            ExampleDirSpec(
                 conftest="pytest_plugins = ['pytest_ipynb2.plugin']",
                 files=[
                     Path("tests/assets/test_module.py"),
@@ -196,7 +196,7 @@ parametrized = pytest.mark.parametrize(
             id="mixed file types",
         ),
         pytest.param(
-            ExampleDir(
+            ExampleDirSpec(
                 conftest="pytest_plugins = ['pytest_ipynb2.plugin']",
                 notebooks={
                     "globals": [
@@ -215,7 +215,7 @@ parametrized = pytest.mark.parametrize(
             id="cell execution order",
         ),
         pytest.param(
-            ExampleDir(
+            ExampleDirSpec(
                 conftest="pytest_plugins = ['pytest_ipynb2.plugin']",
                 files=[Path("tests/assets/test_module.py")],
             ),
@@ -226,7 +226,7 @@ parametrized = pytest.mark.parametrize(
             id="output python module",
         ),
         pytest.param(
-            ExampleDir(
+            ExampleDirSpec(
                 conftest="pytest_plugins = ['pytest_ipynb2.plugin']",
                 ini="addopts = -vv",
                 notebooks={

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -13,9 +13,6 @@ LINEEND = "$"
 WHITESPACE = r"\s*"
 
 
-# TODO(MusicalNinjaDad): #30 Cache runpytest() results or set scopes to speed up tests
-
-
 @dataclass
 class ExpectedResults:
     outcomes: dict[str, int]

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -24,7 +24,7 @@ def pytester_results(
     testname = request.function.__name__.removeprefix("test_")
     expected = getattr(expected_results, testname)
     if expected or expected is None:
-        return example_dir.pytester.runpytest()
+        return example_dir.runresult
     pytest.skip(reason="No expected result")
 
 

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -14,18 +14,6 @@ WHITESPACE = r"\s*"
 
 
 # TODO(MusicalNinjaDad): #30 Cache runpytest() results or set scopes to speed up tests
-@pytest.fixture
-def pytester_results(
-    example_dir: ExampleDir,
-    expected_results: ExpectedResults,
-    request: pytest.FixtureRequest,
-) -> pytest.RunResult:
-    """Skip if no expected result, otherwise runpytest in the example_dir and return the result."""
-    testname = request.function.__name__.removeprefix("test_")
-    expected = getattr(expected_results, testname)
-    if expected or expected is None:
-        return example_dir.runresult
-    pytest.skip(reason="No expected result")
 
 
 @dataclass
@@ -299,7 +287,9 @@ def test_summary(example_dir: ExampleDir, expected_results: ExpectedResults):
     else:
         assert (
             re.search(
-                f"{LINESTART}{summary_regexes[0]}{LINEEND}", str(example_dir.runresult.stdout), flags=re.MULTILINE,
+                f"{LINESTART}{summary_regexes[0]}{LINEEND}",
+                str(example_dir.runresult.stdout),
+                flags=re.MULTILINE,
             )
             is None
         )

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -269,6 +269,7 @@ def test_outcomes(example_dir: ExampleDir, expected_results: ExpectedResults):
 
 
 @parametrized
+@pytest.mark.autoskip
 def test_logreport(example_dir: ExampleDir, expected_results: ExpectedResults):
     stdout_regexes = [
         f"{LINESTART}{re.escape(filename)}{WHITESPACE}"

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -24,7 +24,7 @@ def pytester_results(
     testname = request.function.__name__.removeprefix("test_")
     expected = getattr(expected_results, testname)
     if expected or expected is None:
-        return example_dir.pytester_instance.runpytest()
+        return example_dir.pytester.runpytest()
     pytest.skip(reason="No expected result")
 
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -80,6 +80,13 @@ tests = [
     ),
 ]
 
+@pytest.mark.parametrize(
+    ["example_dir", "expected_files"],
+    tests,
+    indirect=["example_dir"],
+)
+def test_path(example_dir: CollectedDir, expected_files):  # noqa: ARG001
+    assert example_dir.path == example_dir.pytester_instance.path
 
 @pytest.mark.parametrize(
     ["example_dir", "expected_files"],
@@ -87,7 +94,7 @@ tests = [
     indirect=["example_dir"],
 )
 def test_filesexist(example_dir: CollectedDir, expected_files: list[str]):
-    tmp_path = example_dir.pytester_instance.path
+    tmp_path = example_dir.path
     files_exist = ((tmp_path / expected_file).exists() for expected_file in expected_files)
     assert all(files_exist), f"These are not the files you are looking for: {list(tmp_path.iterdir())}"
 
@@ -98,7 +105,7 @@ def test_filesexist(example_dir: CollectedDir, expected_files: list[str]):
     indirect=["example_dir"],
 )
 def test_filecontents(example_dir: CollectedDir, expected_files: dict[str, list[str]]):
-    tmp_path = example_dir.pytester_instance.path
+    tmp_path = example_dir.path
     for filename, expected_contents in expected_files.items():
         if expected_contents is not None:
             nb = nbformat.read(fp=tmp_path / filename, as_version=nbformat.NO_CONVERT)

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -8,14 +8,14 @@ from pytest_ipynb2._pytester_helpers import CollectedDir, ExampleDir, add_ipytes
 tests = [
     pytest.param(
         ExampleDir(
-            [Path("tests/assets/test_module.py").absolute()],
+            files=[Path("tests/assets/test_module.py").absolute()],
         ),
         {"test_module.py": None},
         id="One File",
     ),
     pytest.param(
         ExampleDir(
-            [Path("tests/assets/test_module.py").absolute(), Path("tests/assets/test_othermodule.py").absolute()],
+            files=[Path("tests/assets/test_module.py").absolute(), Path("tests/assets/test_othermodule.py").absolute()],
         ),
         {
             "test_module.py": None,
@@ -25,7 +25,7 @@ tests = [
     ),
     pytest.param(
         ExampleDir(
-            [Path("tests/assets/notebook.ipynb").absolute()],
+            files=[Path("tests/assets/notebook.ipynb").absolute()],
         ),
         {"notebook.ipynb": None},
         id="Copied Notebook",

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -113,8 +113,7 @@ def test_filecontents(example_dir: ExampleDir, expected_files: dict[str, list[st
             nb = nbformat.read(fp=tmp_path / filename, as_version=nbformat.NO_CONVERT)
             assert [cell.source for cell in nb.cells] == expected_contents
 
+
 def test_hashable_spec():
-    spec = ExampleDirSpec(
-            files=[Path("tests/assets/test_module.py").absolute()],
-        )
+    spec = ExampleDirSpec(files=[Path("tests/assets/test_module.py").absolute()])
     assert {spec: None}

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -3,18 +3,18 @@ from pathlib import Path
 import nbformat
 import pytest
 
-from pytest_ipynb2._pytester_helpers import CollectedDir, ExampleDir, add_ipytest_magic
+from pytest_ipynb2._pytester_helpers import ExampleDir, ExampleDirSpec, add_ipytest_magic
 
 tests = [
     pytest.param(
-        ExampleDir(
+        ExampleDirSpec(
             files=[Path("tests/assets/test_module.py").absolute()],
         ),
         {"test_module.py": None},
         id="One File",
     ),
     pytest.param(
-        ExampleDir(
+        ExampleDirSpec(
             files=[Path("tests/assets/test_module.py").absolute(), Path("tests/assets/test_othermodule.py").absolute()],
         ),
         {
@@ -24,14 +24,14 @@ tests = [
         id="Two files",
     ),
     pytest.param(
-        ExampleDir(
+        ExampleDirSpec(
             files=[Path("tests/assets/notebook.ipynb").absolute()],
         ),
         {"notebook.ipynb": None},
         id="Copied Notebook",
     ),
     pytest.param(
-        ExampleDir(
+        ExampleDirSpec(
             notebooks={"generated": [add_ipytest_magic(Path("tests/assets/test_passing.py").read_text())]},
         ),
         {
@@ -49,7 +49,7 @@ tests = [
         id="Generated Notebook",
     ),
     pytest.param(
-        ExampleDir(
+        ExampleDirSpec(
             notebooks={
                 "generated": [
                     Path("tests/assets/import_ipytest.py").read_text(),
@@ -80,20 +80,22 @@ tests = [
     ),
 ]
 
-@pytest.mark.parametrize(
-    ["example_dir", "expected_files"],
-    tests,
-    indirect=["example_dir"],
-)
-def test_path(example_dir: CollectedDir, expected_files):  # noqa: ARG001
-    assert example_dir.path == example_dir.pytester_instance.path
 
 @pytest.mark.parametrize(
     ["example_dir", "expected_files"],
     tests,
     indirect=["example_dir"],
 )
-def test_filesexist(example_dir: CollectedDir, expected_files: list[str]):
+def test_path(example_dir: ExampleDir, expected_files):  # noqa: ARG001
+    assert example_dir.path == example_dir.pytester_instance.path
+
+
+@pytest.mark.parametrize(
+    ["example_dir", "expected_files"],
+    tests,
+    indirect=["example_dir"],
+)
+def test_filesexist(example_dir: ExampleDir, expected_files: list[str]):
     tmp_path = example_dir.path
     files_exist = ((tmp_path / expected_file).exists() for expected_file in expected_files)
     assert all(files_exist), f"These are not the files you are looking for: {list(tmp_path.iterdir())}"
@@ -104,7 +106,7 @@ def test_filesexist(example_dir: CollectedDir, expected_files: list[str]):
     tests,
     indirect=["example_dir"],
 )
-def test_filecontents(example_dir: CollectedDir, expected_files: dict[str, list[str]]):
+def test_filecontents(example_dir: ExampleDir, expected_files: dict[str, list[str]]):
     tmp_path = example_dir.path
     for filename, expected_contents in expected_files.items():
         if expected_contents is not None:

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -112,3 +112,9 @@ def test_filecontents(example_dir: ExampleDir, expected_files: dict[str, list[st
         if expected_contents is not None:
             nb = nbformat.read(fp=tmp_path / filename, as_version=nbformat.NO_CONVERT)
             assert [cell.source for cell in nb.cells] == expected_contents
+
+def test_hashable_spec():
+    spec = ExampleDirSpec(
+            files=[Path("tests/assets/test_module.py").absolute()],
+        )
+    assert {spec: None}

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -87,7 +87,7 @@ tests = [
     indirect=["example_dir"],
 )
 def test_path(example_dir: ExampleDir, expected_files):  # noqa: ARG001
-    assert example_dir.path == example_dir.pytester_instance.path
+    assert example_dir.path == example_dir.pytester.path
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
See also #30

## Summary by Sourcery

This pull request improves test execution times by caching the `example_dir` fixture and adding markers for skipping and xfailing tests. It also updates the tests to use the cached fixture and the new markers.

Enhancements:
- Cache the `example_dir` fixture to improve test execution times by reusing the same directory and files for multiple tests.
- Add `autoskip` marker to automatically skip tests if expected results are not provided, avoiding unnecessary test executions.
- Add `xfail_for` marker to dynamically xfail tests based on specified conditions.

Tests:
- Update tests to use the cached `example_dir` fixture and the new markers for skipping and xfailing tests.

Chores:
- Remove the `pytester_results` fixture as it is no longer needed with the cached `example_dir` fixture.