### PR TITLE
Coverage

### DIFF
--- a/.github/workflows/check-coverage.yml
+++ b/.github/workflows/check-coverage.yml
@@ -7,28 +7,35 @@ on:
       - '.github/workflows/check-coverage.yml'
       - 'codecov.yml'
 
-env:
-  python-version: '3.13'
-
 permissions:
   id-token: write
 
 jobs:
   python:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [
+            "3.9",
+            "3.10",
+            "3.11",
+            "3.12",
+            "3.13"
+        ]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.python-version }}
+          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
-          python-version: ${{ env.python-version }}
-      - name: Test with pytest
+          python-version: ${{ matrix.python-version }}
+      - name: Run coverage
         run: |
-          uv run --no-default-groups --group cov pytest --cov --cov-report=xml --cov-context=test # Context info not yet supported in cobertura (or any other common format between pytest-cov and codecov.io)
+          uv run --no-default-groups --group cov coverage run --context=${{ matrix.python-version }} -m pytest
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,2 @@
-codecov:
-  comment:
-    after_n_builds: 5
+comment:
+  after_n_builds: 5

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+codecov:
+  comment:
+    after_n_builds: 5

--- a/justfile
+++ b/justfile
@@ -69,8 +69,11 @@ format:
 #run coverage analysis on python code
 cov:
   uv run coverage erase
-  uv run coverage run --context=3.13 -m pytest 
+  rm -rf pycov
+  uv run --python 3.13 coverage run --context=3.13 -m pytest 
   UV_PROJECT_ENVIRONMENT="./.venv-3.12" uv run --python 3.12 coverage run --context=3.12 --append -m pytest
+  UV_PROJECT_ENVIRONMENT="./.venv-3.11" uv run --python 3.11 coverage run --context=3.11 --append -m pytest
+  UV_PROJECT_ENVIRONMENT="./.venv-3.10" uv run --python 3.10 coverage run --context=3.10 --append -m pytest
   UV_PROJECT_ENVIRONMENT="./.venv-3.9" uv run --python 3.9 coverage run --context=3.9 --append -m pytest
   uv run coverage report
   uv run coverage html --show-contexts -d pycov

--- a/justfile
+++ b/justfile
@@ -68,7 +68,12 @@ format:
 
 #run coverage analysis on python code
 cov:
-  uv run pytest --cov --cov-report html:pycov --cov-report term --cov-context=test
+  uv run coverage erase
+  uv run coverage run --context=3.13 -m pytest 
+  UV_PROJECT_ENVIRONMENT="./.venv-3.12" uv run --python 3.12 coverage run --context=3.12 --append -m pytest
+  UV_PROJECT_ENVIRONMENT="./.venv-3.9" uv run --python 3.9 coverage run --context=3.9 --append -m pytest
+  uv run coverage report
+  uv run coverage html --show-contexts -d pycov
 
 # serve python coverage results on localhost:8000 (doesn't run coverage analysis)
 show-cov:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@
     ]
     test = ["pytest-doctest-mkdocstrings"]
     cov_unique = [
-        "pytest-cov",
+        "coverage",
     ]
     cov = [
         { include-group = "test" },
@@ -103,6 +103,7 @@
 [tool.coverage.run]
     branch = true
     source = ["pytest_ipynb2"]
+    dynamic_context = "test_function"
 
 [tool.coverage.report]
     exclude_also = [

--- a/pytest_ipynb2/_cellpath.py
+++ b/pytest_ipynb2/_cellpath.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 CELL_PREFIX: Final[str] = "Cell"
 
-if sys.version_info < (3, 12):  # pragma: no cover
+if sys.version_info < (3, 12):
     # Can't subclass `pathlib.Path` directly in python < 3.12
     _Path = Path
     Path: Final[type] = type(_Path())
@@ -43,7 +43,7 @@ class CellPath(Path):
         # TODO: #33 Extend `CellPath.exists` to also check that the cell exists (if performance allows)
         return self.notebook.exists(*args, **kwargs)
 
-    if sys.version_info < (3, 13):  # pragma: no cover
+    if sys.version_info < (3, 13):
 
         def relative_to(self, other: PathLike, *args: Any, **kwargs: Any) -> Self:
             """Relative_to only works out-of-the-box on python 3.13 and above."""

--- a/pytest_ipynb2/_pytester_helpers.py
+++ b/pytest_ipynb2/_pytester_helpers.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     with suppress(ImportError):
         from typing import Self  # not type-checking on python < 3.11 so don't care if this fails
 
-if sys.version_info < (3, 10):  # dataclass does not offer kw_only on python < 3.10 # pragma: no cover
+if sys.version_info < (3, 10):  # dataclass does not offer kw_only on python < 3.10
     _dataclass = dataclass
 
     def dataclass(*args, **kwargs):  # noqa: ANN002, ANN003
@@ -184,7 +184,7 @@ class CollectionTree:
         return f"{self.node!r}\n{children_repr}\n"
 
 
-class ExampleDir:
+class ExampleDir: # pragma: no cover
     """
     A directory containing example files and the associated pytester instance.
 
@@ -243,7 +243,7 @@ class ExampleDirRequest(FunctionRequest):
 
 
 @pytest.fixture(scope="module")
-def example_dir_cache() -> dict[ExampleDirSpec, ExampleDir]:
+def example_dir_cache() -> dict[ExampleDirSpec, ExampleDir]: # pragma: no cover
     return {}
 
 
@@ -257,10 +257,10 @@ def example_dir(
     example = request.param
     if (cached_dir := example_dir_cache.get(example)) is None:
         (pytester.path / example.path).mkdir(parents=True, exist_ok=True)
-        if example.conftest:
+        if example.conftest: # pragma: no cover
             pytester.makeconftest(request.param.conftest)
 
-        if example.ini:
+        if example.ini: # pragma: no cover
             pytester.makeini(f"[pytest]\n{example.ini}")
 
         for filetocopy in example.files:
@@ -285,7 +285,7 @@ def add_ipytest_magic(source: str) -> str:
     return f"%%ipytest\n\n{source}"
 
 
-def pytest_configure(config: pytest.Config) -> None:  # pragma: no cover
+def pytest_configure(config: pytest.Config) -> None:
     # Tests will be needed if this ever becomes public functionality
     """Register autoskip & xfail_for marks."""
     config.addinivalue_line("markers", "autoskip: automatically skip test if expected results not provided")


### PR DESCRIPTION
Fixes #53
Helps towards #34

## Summary by Sourcery

Improve test coverage reporting by configuring the CI workflow to run coverage on multiple Python versions and upload the results to Codecov. Also, update the justfile to run coverage for all python versions.

CI:
- Run coverage on multiple Python versions in CI and upload the results to Codecov.
- Use a matrix strategy to run tests on multiple Python versions.
- Configure Codecov to comment after 5 builds.
- Fixes the coverage check workflow to use uv instead of pip

Tests:
- Enable coverage for all python versions