### PR TITLE
Simplify future code cleaning when python versions go out of support

### DIFF
--- a/pytest_ipynb2/_parser.py
+++ b/pytest_ipynb2/_parser.py
@@ -11,12 +11,8 @@ import nbformat
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Generator, Iterator, Sequence
-    from contextlib import suppress
     from pathlib import Path
-    from typing import SupportsIndex
-
-    with suppress(ImportError):  # not type-checking on python < 3.11
-        from typing import Self
+    from typing import Self, SupportsIndex
 
 
 class MagicFinder(ast.NodeVisitor):

--- a/pytest_ipynb2/_pytester_helpers.py
+++ b/pytest_ipynb2/_pytester_helpers.py
@@ -14,12 +14,8 @@ import nbformat
 import pytest
 
 if TYPE_CHECKING:
-    from contextlib import suppress
     from types import FunctionType
-    from typing import Any
-
-    with suppress(ImportError):
-        from typing import Self  # not type-checking on python < 3.11 so don't care if this fails
+    from typing import Any, Self
 
 if sys.version_info < (3, 10):  # dataclass does not offer kw_only on python < 3.10
     _dataclass = dataclass


### PR DESCRIPTION
fixes #34

Allows us to rely on test coverage to identify when we can remove code in place to handle older versions of python.

## Summary by Sourcery

Enhancements:
- Removes `contextlib.suppress` blocks for conditional imports.